### PR TITLE
feat(validation): support multiple delimiters, and return multiple validation errors, and return headers

### DIFF
--- a/TinyCsvParser/TinyCsvParser.Benchmark/Program.cs
+++ b/TinyCsvParser/TinyCsvParser.Benchmark/Program.cs
@@ -52,6 +52,7 @@ namespace TinyCsvParser.Benchmark
             var csvParser = new CsvParser<LocalWeatherData>(csvParserOptions, csvMapper);
 
             float result = csvParser.ReadFromFile(GetTestFilePath(), Encoding.ASCII)
+                .result
                 .Where(x => x.IsValid)
                 .Select(x => x.Result)
                 .Average(x => x.DryBulbCelsius);

--- a/TinyCsvParser/TinyCsvParser.Benchmark/Program.cs
+++ b/TinyCsvParser/TinyCsvParser.Benchmark/Program.cs
@@ -3,11 +3,9 @@
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using TinyCsvParser.Benchmark.Mapper;
 using TinyCsvParser.Benchmark.Model;
 
@@ -16,7 +14,7 @@ namespace TinyCsvParser.Benchmark
     [MemoryDiagnoser]
     public class TinyCsvParserBenchmarks
     {
-        
+
 
         [GlobalSetup]
         public void SetupBenchmarkData()
@@ -29,13 +27,13 @@ namespace TinyCsvParser.Benchmark
 
             var testFilePath = GetTestFilePath();
 
-            using (var fileStream = File.Create(testFilePath)) 
+            using (var fileStream = File.Create(testFilePath))
             {
                 using (var streamWriter = new StreamWriter(fileStream, Encoding.ASCII))
                 {
                     streamWriter.WriteLine(csvHeader);
 
-                    for(int i = 0; i < numLinesToGenerate; i++)
+                    for (int i = 0; i < numLinesToGenerate; i++)
                     {
                         streamWriter.WriteLine(csvLine);
                     }
@@ -52,7 +50,7 @@ namespace TinyCsvParser.Benchmark
             var csvParser = new CsvParser<LocalWeatherData>(csvParserOptions, csvMapper);
 
             float result = csvParser.ReadFromFile(GetTestFilePath(), Encoding.ASCII)
-                .result
+                .Items
                 .Where(x => x.IsValid)
                 .Select(x => x.Result)
                 .Average(x => x.DryBulbCelsius);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserArrayTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserArrayTest.cs
@@ -31,7 +31,7 @@ namespace TinyCsvParser.Test.CsvParser
         [Test]
         public void FloatArraysTest()
         {
-            CsvParserOptions csvParserOptions = new CsvParserOptions(false, ';' );
+            CsvParserOptions csvParserOptions = new CsvParserOptions(false, ';');
             CsvReaderOptions csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
             CsvMeasurementMapping csvMapper = new CsvMeasurementMapping();
             CsvParser<Measurement> csvParser = new CsvParser<Measurement>(csvParserOptions, csvMapper);
@@ -43,7 +43,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserArrayTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserArrayTest.cs
@@ -43,6 +43,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserExtensionsTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserExtensionsTest.cs
@@ -62,6 +62,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromFile(filePath.ToString(), Encoding.UTF8)
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
@@ -116,6 +117,7 @@ namespace TinyCsvParser.Test.CsvParser
             {
                 var result = csvParser
                     .ReadFromStream(stream, Encoding.UTF8)
+                    .result
                     .ToList();
 
                 Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserExtensionsTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserExtensionsTest.cs
@@ -62,7 +62,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromFile(filePath.ToString(), Encoding.UTF8)
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
@@ -117,7 +117,7 @@ namespace TinyCsvParser.Test.CsvParser
             {
                 var result = csvParser
                     .ReadFromStream(stream, Encoding.UTF8)
-                    .result
+                    .Items
                     .ToList();
 
                 Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserTest.cs
@@ -72,6 +72,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
@@ -109,6 +110,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
@@ -147,6 +149,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                        .result
                 .ToList();
 
             Assert.AreEqual(0, result.Count);
@@ -167,6 +170,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
@@ -203,6 +207,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .Where(x => x.IsValid)
                 .Where(x => x.Result.FirstName == "Philipp")
                 .ToList();
@@ -232,6 +237,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .Where(x => x.IsValid)
                 .ToList();
 
@@ -259,6 +265,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/CsvParserTest.cs
@@ -32,7 +32,7 @@ namespace TinyCsvParser.Test.CsvParser
         [Test]
         public void NullInputTest()
         {
-            CsvParserOptions csvParserOptions = new CsvParserOptions(true, ';' );
+            CsvParserOptions csvParserOptions = new CsvParserOptions(true, ';');
             CsvReaderOptions csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
             CsvPersonMapping csvMapper = new CsvPersonMapping();
             CsvParser<Person> csvParser = new CsvParser<Person>(csvParserOptions, csvMapper);
@@ -46,7 +46,7 @@ namespace TinyCsvParser.Test.CsvParser
         [Test]
         public void ToStringTest()
         {
-            CsvParserOptions csvParserOptions = new CsvParserOptions(true,  ';');
+            CsvParserOptions csvParserOptions = new CsvParserOptions(true, ';');
             CsvReaderOptions csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
             CsvPersonMapping csvMapper = new CsvPersonMapping();
             CsvParser<Person> csvParser = new CsvParser<Person>(csvParserOptions, csvMapper);
@@ -72,7 +72,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
@@ -110,7 +110,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
@@ -149,7 +149,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                        .result
+                        .Items
                 .ToList();
 
             Assert.AreEqual(0, result.Count);
@@ -170,7 +170,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
@@ -207,7 +207,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .Where(x => x.IsValid)
                 .Where(x => x.Result.FirstName == "Philipp")
                 .ToList();
@@ -225,7 +225,7 @@ namespace TinyCsvParser.Test.CsvParser
         [Test]
         public void CommentLineTest()
         {
-            CsvParserOptions csvParserOptions = new CsvParserOptions(true, "#", new StringSplitTokenizer(new [] {';'}, false));
+            CsvParserOptions csvParserOptions = new CsvParserOptions(true, "#", new StringSplitTokenizer(new[] { ';' }, false));
             CsvReaderOptions csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
             CsvPersonMapping csvMapper = new CsvPersonMapping();
             CsvParser<Person> csvParser = new CsvParser<Person>(csvParserOptions, csvMapper);
@@ -237,7 +237,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .Where(x => x.IsValid)
                 .ToList();
 
@@ -265,7 +265,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/CustomTypeConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/CustomTypeConverterTest.cs
@@ -69,6 +69,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual("Philipp", result[0].Result.FirstName);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/CustomTypeConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/CustomTypeConverterTest.cs
@@ -58,7 +58,7 @@ namespace TinyCsvParser.Test.CsvParser
         [Test]
         public void WeirdDateTimeTest_CustomConverterBased()
         {
-            CsvParserOptions csvParserOptions = new CsvParserOptions(true,  ';');
+            CsvParserOptions csvParserOptions = new CsvParserOptions(true, ';');
             CsvReaderOptions csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
             CsvPersonMappingWithCustomConverter csvMapper = new CsvPersonMappingWithCustomConverter();
             CsvParser<Person> csvParser = new CsvParser<Person>(csvParserOptions, csvMapper);
@@ -69,7 +69,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual("Philipp", result[0].Result.FirstName);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/EnumConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/EnumConverterTest.cs
@@ -49,6 +49,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(VehicleTypeEnum.Car, result[0].Result.VehicleType);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/EnumConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/EnumConverterTest.cs
@@ -49,7 +49,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(VehicleTypeEnum.Car, result[0].Result.VehicleType);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/MapUsingTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/MapUsingTest.cs
@@ -65,6 +65,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/CsvParser/MapUsingTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/CsvParser/MapUsingTest.cs
@@ -54,7 +54,7 @@ namespace TinyCsvParser.Test.CsvParser
         [Test]
         public void MapUsingTest()
         {
-            CsvParserOptions csvParserOptions = new CsvParserOptions(false, ';' );
+            CsvParserOptions csvParserOptions = new CsvParserOptions(false, ';');
             CsvReaderOptions csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
             CsvMainClassMapping csvMapper = new CsvMainClassMapping();
             CsvParser<MainClass> csvParser = new CsvParser<MainClass>(csvParserOptions, csvMapper);
@@ -65,16 +65,16 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
 
             Assert.IsFalse(result[0].IsValid);
             Assert.IsTrue(result[1].IsValid);
-            
+
             Assert.AreEqual("A", result[1].Result.Property1);
-            
+
             Assert.IsNotNull(result[1].Result.SubClass);
 
             Assert.AreEqual("B", result[1].Result.SubClass.Property2);

--- a/TinyCsvParser/TinyCsvParser.Test/Examples/CustomConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Examples/CustomConverterTest.cs
@@ -69,6 +69,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(null, result[0].Result.Property);

--- a/TinyCsvParser/TinyCsvParser.Test/Examples/CustomConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Examples/CustomConverterTest.cs
@@ -56,7 +56,7 @@ namespace TinyCsvParser.Test.CsvParser
         [Test]
         public void ParseWithNULLStringTest()
         {
-            CsvParserOptions csvParserOptions = new CsvParserOptions(false,  ';');
+            CsvParserOptions csvParserOptions = new CsvParserOptions(false, ';');
             CsvReaderOptions csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
             CsvEntityMapping csvMapper = new CsvEntityMapping();
             CsvParser<Entity> csvParser = new CsvParser<Entity>(csvParserOptions, csvMapper);
@@ -69,7 +69,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(null, result[0].Result.Property);

--- a/TinyCsvParser/TinyCsvParser.Test/Examples/DoubleConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Examples/DoubleConverterTest.cs
@@ -29,7 +29,7 @@ namespace TinyCsvParser.Test.CsvParser
         [Test]
         public void ParseWithNULLStringTest()
         {
-            CsvParserOptions csvParserOptions = new CsvParserOptions(false,  ';');
+            CsvParserOptions csvParserOptions = new CsvParserOptions(false, ';');
             CsvReaderOptions csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
             CsvEntityMapping csvMapper = new CsvEntityMapping();
             CsvParser<Entity> csvParser = new CsvParser<Entity>(csvParserOptions, csvMapper);
@@ -39,7 +39,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(123.456, result[0].Result.Value);

--- a/TinyCsvParser/TinyCsvParser.Test/Examples/DoubleConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Examples/DoubleConverterTest.cs
@@ -39,6 +39,7 @@ namespace TinyCsvParser.Test.CsvParser
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(123.456, result[0].Result.Value);

--- a/TinyCsvParser/TinyCsvParser.Test/Examples/PolymorphismWithMapUsingTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Examples/PolymorphismWithMapUsingTest.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using NUnit.Framework;
 using System;
 using System.Linq;
 using System.Text;
-using NUnit.Framework;
 using TinyCsvParser.Mapping;
 using TinyCsvParser.Model;
 
@@ -19,7 +19,7 @@ namespace TinyCsvParser.Test.Examples
             public Shape Shape { get; set; }
         }
 
-        private abstract class Shape  {}
+        private abstract class Shape { }
 
         private class Square : Shape
         {
@@ -77,7 +77,7 @@ namespace TinyCsvParser.Test.Examples
 
                     return subMap.IsValid;
                 }
-                
+
                 // NOTE: There are two possible strategies here. One, you can return true
                 // which will allow any *OTHER* Row Mappings to run and see if they can make
                 // sense of the data from this row. Maybe you have a whole separate mapper
@@ -89,7 +89,7 @@ namespace TinyCsvParser.Test.Examples
             }
         }
 
-        
+
         // NOTE: These "sub" maps aren't referenced directly by the CsvParser, but instead
         // by the top-level map, which conditionally uses them based on the contents of a
         // given row.
@@ -132,7 +132,7 @@ namespace TinyCsvParser.Test.Examples
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(4, result.Count);
@@ -144,13 +144,13 @@ namespace TinyCsvParser.Test.Examples
 
             Assert.AreEqual("square", result[0].Result.ShapeName);
             Assert.AreEqual(typeof(Square), result[0].Result.Shape.GetType());
-            Assert.AreEqual(10, ((Square) result[0].Result.Shape).Width);
+            Assert.AreEqual(10, ((Square)result[0].Result.Shape).Width);
 
             Assert.AreEqual("triangle", result[1].Result.ShapeName);
             Assert.AreEqual(typeof(Triangle), result[1].Result.Shape.GetType());
-            Assert.AreEqual(3, ((Triangle) result[1].Result.Shape).Side1);
-            Assert.AreEqual(4, ((Triangle) result[1].Result.Shape).Side2);
-            Assert.AreEqual(5, ((Triangle) result[1].Result.Shape).Side3);
+            Assert.AreEqual(3, ((Triangle)result[1].Result.Shape).Side1);
+            Assert.AreEqual(4, ((Triangle)result[1].Result.Shape).Side2);
+            Assert.AreEqual(5, ((Triangle)result[1].Result.Shape).Side3);
 
         }
 

--- a/TinyCsvParser/TinyCsvParser.Test/Examples/PolymorphismWithMapUsingTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Examples/PolymorphismWithMapUsingTest.cs
@@ -58,7 +58,7 @@ namespace TinyCsvParser.Test.Examples
                 // the process of building.
                 if (inProgressEntity.ShapeName == "square")
                 {
-                    var subMap = squareMap.Map(rowData);
+                    var subMap = squareMap.Map(rowData, 1);
                     if (subMap.IsValid)
                     {
                         inProgressEntity.Shape = subMap.Result;
@@ -69,7 +69,7 @@ namespace TinyCsvParser.Test.Examples
 
                 if (inProgressEntity.ShapeName == "triangle")
                 {
-                    var subMap = triangleMap.Map(rowData);
+                    var subMap = triangleMap.Map(rowData, 1);
                     if (subMap.IsValid)
                     {
                         inProgressEntity.Shape = subMap.Result;
@@ -132,6 +132,7 @@ namespace TinyCsvParser.Test.Examples
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(4, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Integration/BasicExampleTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Integration/BasicExampleTest.cs
@@ -43,7 +43,7 @@ namespace TinyCsvParser.Test.Integration
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Integration/BasicExampleTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Integration/BasicExampleTest.cs
@@ -43,6 +43,7 @@ namespace TinyCsvParser.Test.Integration
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Integration/NCsvPerfBenchmark.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Integration/NCsvPerfBenchmark.cs
@@ -153,6 +153,7 @@ namespace TinyCsvParser.Test.Integration
                 {
                     var cnt = parser
                         .ReadFromFile(filename, Encoding.UTF8)
+                        .result
                         .Where(x => x.IsValid)
                         .Count();
     
@@ -176,6 +177,7 @@ namespace TinyCsvParser.Test.Integration
                 {
                     var cnt = parser
                         .ReadFromFile(filename, Encoding.UTF8)
+                        .result
                         .Where(x => x.IsValid)
                         .Count();
 
@@ -199,6 +201,7 @@ namespace TinyCsvParser.Test.Integration
                 {
                     var cnt = parser
                         .ReadFromFile(filename, Encoding.UTF8)
+                        .result
                         .Where(x => x.IsValid)
                         .Count();
 

--- a/TinyCsvParser/TinyCsvParser.Test/Integration/NCsvPerfBenchmark.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Integration/NCsvPerfBenchmark.cs
@@ -1,11 +1,9 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using TinyCsvParser.Mapping;
 using TinyCsvParser.Tokenizer;
 using TinyCsvParser.Tokenizer.RFC4180;
@@ -153,10 +151,10 @@ namespace TinyCsvParser.Test.Integration
                 {
                     var cnt = parser
                         .ReadFromFile(filename, Encoding.UTF8)
-                        .result
+                        .Items
                         .Where(x => x.IsValid)
                         .Count();
-    
+
                     TestContext.WriteLine($"Parsed {cnt} valid lines ...");
                 },
                 timespanFormatter: x => $"{x.TotalMilliseconds} Milliseconds");
@@ -177,7 +175,7 @@ namespace TinyCsvParser.Test.Integration
                 {
                     var cnt = parser
                         .ReadFromFile(filename, Encoding.UTF8)
-                        .result
+                        .Items
                         .Where(x => x.IsValid)
                         .Count();
 
@@ -201,7 +199,7 @@ namespace TinyCsvParser.Test.Integration
                 {
                     var cnt = parser
                         .ReadFromFile(filename, Encoding.UTF8)
-                        .result
+                        .Items
                         .Where(x => x.IsValid)
                         .Count();
 

--- a/TinyCsvParser/TinyCsvParser.Test/Integration/TokenizerBenchmark.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Integration/TokenizerBenchmark.cs
@@ -84,6 +84,7 @@ namespace TinyCsvParser.Test.Integration
             {
                 var lines = parser
                     .ReadFromFile(testFilePath, Encoding.UTF8)
+                    .result
                     .Where(x => x.IsValid)
                     .Count();
 

--- a/TinyCsvParser/TinyCsvParser.Test/Integration/TokenizerBenchmark.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Integration/TokenizerBenchmark.cs
@@ -3,7 +3,6 @@
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -42,11 +41,11 @@ namespace TinyCsvParser.Test.Integration
                 var result = new List<string>();
 
                 bool isInQuotes = false;
-                
+
                 var chars = input.ToCharArray();
-                
+
                 StringBuilder str = new StringBuilder(string.Empty);
-                
+
                 foreach (var t in chars)
                 {
                     if (t == '"')
@@ -84,7 +83,7 @@ namespace TinyCsvParser.Test.Integration
             {
                 var lines = parser
                     .ReadFromFile(testFilePath, Encoding.UTF8)
-                    .result
+                    .Items
                     .Where(x => x.IsValid)
                     .Count();
 
@@ -97,7 +96,7 @@ namespace TinyCsvParser.Test.Integration
         {
             StringBuilder stringBuilder = new StringBuilder();
 
-            for(int i = 0; i < 100000; i++)
+            for (int i = 0; i < 100000; i++)
             {
                 stringBuilder.AppendLine("1312452433443,93742834623543,234277237242");
             }

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue2_NegativeValueTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue2_NegativeValueTest.cs
@@ -39,6 +39,7 @@ namespace TinyCsvParser.Test.Issues
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(1, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue2_NegativeValueTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue2_NegativeValueTest.cs
@@ -39,11 +39,11 @@ namespace TinyCsvParser.Test.Issues
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(1, result.Count);
-            
+
             Assert.IsTrue(result.All(x => x.IsValid));
 
             Assert.AreEqual(-1, result.First().Result.Value);

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue34_TrimLineTests.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue34_TrimLineTests.cs
@@ -55,6 +55,7 @@ namespace TinyCsvParser.Test.Issues
             {
                 var result = csvParser
                     .ReadFromString(csvReaderOptions, csvLine)
+                    .result
                     .ToList();
 
                 Assert.AreEqual(1, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue34_TrimLineTests.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue34_TrimLineTests.cs
@@ -3,8 +3,6 @@
 using NUnit.Framework;
 using System;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
 using TinyCsvParser.Mapping;
 using TinyCsvParser.Tokenizer;
 
@@ -55,7 +53,7 @@ namespace TinyCsvParser.Test.Issues
             {
                 var result = csvParser
                     .ReadFromString(csvReaderOptions, csvLine)
-                    .result
+                    .Items
                     .ToList();
 
                 Assert.AreEqual(1, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue4_PreprocessingTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue4_PreprocessingTest.cs
@@ -48,7 +48,7 @@ namespace TinyCsvParser.Test.Issues
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(1, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue4_PreprocessingTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue4_PreprocessingTest.cs
@@ -48,6 +48,7 @@ namespace TinyCsvParser.Test.Issues
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(1, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue60_TrailingComma.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue60_TrailingComma.cs
@@ -56,6 +56,7 @@ namespace TinyCsvParser.Test.Issues
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(1, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue60_TrailingComma.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue60_TrailingComma.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using System.Text;
 using TinyCsvParser.Mapping;
-using TinyCsvParser.Tokenizer;
 
 namespace TinyCsvParser.Test.Issues
 {
@@ -56,7 +55,7 @@ namespace TinyCsvParser.Test.Issues
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(1, result.Count);
@@ -70,7 +69,7 @@ namespace TinyCsvParser.Test.Issues
             Assert.AreEqual(1.00f, result.First().Result.Col4, 1e-3);
             Assert.AreEqual("Teacher", result.First().Result.Col5);
             Assert.AreEqual("js@someemail.org", result.First().Result.Col6);
-            
+
         }
     }
 }

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue63_SkipLast.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue63_SkipLast.cs
@@ -1,12 +1,10 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using NUnit.Framework;
-using System.Threading.Tasks;
 using TinyCsvParser.Mapping;
 using TinyCsvParser.Model;
 
@@ -26,7 +24,7 @@ namespace TinyCsvParser.Test.Issues
                 .SkipLast(skipLast)
                 .Select((line, index) => new Row(index, line));
 
-            return csvParser.Parse(lines).result;
+            return csvParser.Parse(lines).Items;
         }
     }
 

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue63_SkipLast.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue63_SkipLast.cs
@@ -26,7 +26,7 @@ namespace TinyCsvParser.Test.Issues
                 .SkipLast(skipLast)
                 .Select((line, index) => new Row(index, line));
 
-            return csvParser.Parse(lines);
+            return csvParser.Parse(lines).result;
         }
     }
 

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue93_QuotingIssue.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue93_QuotingIssue.cs
@@ -48,6 +48,7 @@ namespace TinyCsvParser.Test.Issues
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, csv)
+                .result
                 .ToList();
 
             Assert.AreEqual(1, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Issues/Issue93_QuotingIssue.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Issues/Issue93_QuotingIssue.cs
@@ -1,9 +1,9 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using NUnit.Framework;
 using System;
 using System.Linq;
 using System.Text;
-using NUnit.Framework;
 using TinyCsvParser.Mapping;
 using TinyCsvParser.Tokenizer;
 
@@ -23,9 +23,9 @@ namespace TinyCsvParser.Test.Issues
 
         }
 
-        private class SomeDtoMapping : CsvMapping<SomeDto> 
+        private class SomeDtoMapping : CsvMapping<SomeDto>
         {
-            public SomeDtoMapping() 
+            public SomeDtoMapping()
             {
                 MapProperty(0, x => x.Column1);
                 MapProperty(1, x => x.Column2);
@@ -48,7 +48,7 @@ namespace TinyCsvParser.Test.Issues
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, csv)
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(1, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Mapping/CsvRangeIgnoringMapping.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Mapping/CsvRangeIgnoringMapping.cs
@@ -1,11 +1,11 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
-using NUnit.Framework;
 using TinyCsvParser.Mapping;
 using TinyCsvParser.Model;
 using TinyCsvParser.TypeConverter;
@@ -162,18 +162,18 @@ namespace TinyCsvParser.Test.Mapping
                 .AppendLine("1;2;3")
                 .AppendLine("4");
 
-            var csvReaderOptions = new CsvReaderOptions(new [] { Environment.NewLine });
+            var csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
 
             var result = customCsvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
 
             Assert.IsTrue(result.All(x => x.IsValid));
 
-            Assert.AreEqual("1",result[0].Result.Value1);
+            Assert.AreEqual("1", result[0].Result.Value1);
             Assert.AreEqual("2", result[0].Result.Value2);
             Assert.AreEqual("3", result[0].Result.Value3);
 

--- a/TinyCsvParser/TinyCsvParser.Test/Mapping/CsvRangeIgnoringMapping.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Mapping/CsvRangeIgnoringMapping.cs
@@ -71,7 +71,7 @@ namespace TinyCsvParser.Test.Mapping
             csvIndexPropertyMappings.Add(indexToPropertyMapping);
         }
 
-        public CsvMappingResult<TEntity> Map(TokenizedRow values)
+        public CsvMappingResult<TEntity> Map(TokenizedRow values, int ignoreColumns = 0)
         {
             TEntity entity = new TEntity();
 
@@ -117,6 +117,16 @@ namespace TinyCsvParser.Test.Mapping
 
             return $"CsvMissingValuesMapping (TypeConverterProvider = {typeConverterProvider}, Mappings = {csvPropertyMappingsString})";
         }
+
+        public CsvHeaderMappingResult MapHeader(TokenizedRow values)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Dictionary<int, string> GetPropertyMapping()
+        {
+            throw new NotImplementedException();
+        }
     }
 
     [TestFixture]
@@ -156,6 +166,7 @@ namespace TinyCsvParser.Test.Mapping
 
             var result = customCsvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Tokenizer/Rfc4180TokenizerTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Tokenizer/Rfc4180TokenizerTest.cs
@@ -56,6 +56,7 @@ namespace TinyCsvParser.Test.Tokenizer
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
@@ -121,6 +122,7 @@ namespace TinyCsvParser.Test.Tokenizer
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Tokenizer/Rfc4180TokenizerTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Tokenizer/Rfc4180TokenizerTest.cs
@@ -50,13 +50,13 @@ namespace TinyCsvParser.Test.Tokenizer
                 .AppendLine("Name, Age, Description")
                 .AppendLine("\"Michael, Chester\",24,\"Also goes by \"\"Mike\"\", among friends that is\"")
                 .AppendLine("\"Robert, Willliamson\", , \"All-around nice guy who always says hi\"");
-            
+
             // Define the NewLine Character to split at:
             CsvReaderOptions csvReaderOptions = new CsvReaderOptions(new[] { Environment.NewLine });
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);
@@ -122,7 +122,7 @@ namespace TinyCsvParser.Test.Tokenizer
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             Assert.AreEqual(2, result.Count);

--- a/TinyCsvParser/TinyCsvParser.Test/Tokenizer/TokenizerExampleTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Tokenizer/TokenizerExampleTest.cs
@@ -42,7 +42,7 @@ namespace TinyCsvParser.Test.Tokenizer
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
-                .result
+                .Items
                 .ToList();
 
             // Make sure we got 2 results:

--- a/TinyCsvParser/TinyCsvParser.Test/Tokenizer/TokenizerExampleTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/Tokenizer/TokenizerExampleTest.cs
@@ -42,6 +42,7 @@ namespace TinyCsvParser.Test.Tokenizer
 
             var result = csvParser
                 .ReadFromString(csvReaderOptions, stringBuilder.ToString())
+                .result
                 .ToList();
 
             // Make sure we got 2 results:

--- a/TinyCsvParser/TinyCsvParser.Test/TypeConverter/DoubleConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/TypeConverter/DoubleConverterTest.cs
@@ -19,8 +19,8 @@ namespace TinyCsvParser.Test.TypeConverter
             get
             {
                 return new[] {
-                    MakeTuple(double.MinValue.ToString("R"), double.NegativeInfinity),
-                    MakeTuple(double.MaxValue.ToString("R"), double.PositiveInfinity),
+                    MakeTuple(double.MinValue.ToString("R"), double.MinValue),
+                    MakeTuple(double.MaxValue.ToString("R"), double.MaxValue),
                     MakeTuple("0", 0),
                     MakeTuple("-1000", -1000),
                     MakeTuple("1000", 1000),

--- a/TinyCsvParser/TinyCsvParser.Test/TypeConverter/NullableDoubleConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/TypeConverter/NullableDoubleConverterTest.cs
@@ -20,8 +20,8 @@ namespace TinyCsvParser.Test.TypeConverter
             get
             {
                 return new[] {
-                    MakeTuple(double.MinValue.ToString("R"), double.NegativeInfinity),
-                    MakeTuple(double.MaxValue.ToString("R"), double.PositiveInfinity),
+                    MakeTuple(double.MinValue.ToString("R"), double.MinValue),
+                    MakeTuple(double.MaxValue.ToString("R"), double.MaxValue),
                     MakeTuple("0", 0),
                     MakeTuple("-1000", -1000),
                     MakeTuple("1000", 1000),

--- a/TinyCsvParser/TinyCsvParser.Test/TypeConverter/NullableSingleConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/TypeConverter/NullableSingleConverterTest.cs
@@ -20,8 +20,8 @@ namespace TinyCsvParser.Test.TypeConverter
             get
             {
                 return new[] {
-                    MakeTuple(float.MinValue.ToString("R"), float.NegativeInfinity),
-                    MakeTuple(float.MaxValue.ToString("R"), float.PositiveInfinity),
+                    MakeTuple(float.MinValue.ToString("R"), float.MinValue),
+                    MakeTuple(float.MaxValue.ToString("R"), float.MaxValue),
                     MakeTuple("0", 0),
                     MakeTuple("-1000", -1000),
                     MakeTuple("1000", 1000),

--- a/TinyCsvParser/TinyCsvParser.Test/TypeConverter/SingleConverterTest.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/TypeConverter/SingleConverterTest.cs
@@ -19,8 +19,8 @@ namespace TinyCsvParser.Test.TypeConverter
             get
             {
                 return new[] {
-                    MakeTuple(float.MinValue.ToString("R"), float.NegativeInfinity),
-                    MakeTuple(float.MaxValue.ToString("R"), float.PositiveInfinity),
+                    MakeTuple(float.MinValue.ToString("R"), float.MinValue),
+                    MakeTuple(float.MaxValue.ToString("R"), float.MaxValue),
                     MakeTuple("0", 0),
                     MakeTuple("-1000", -1000),
                     MakeTuple("1000", 1000),

--- a/TinyCsvParser/TinyCsvParser/CsvParser.cs
+++ b/TinyCsvParser/TinyCsvParser/CsvParser.cs
@@ -24,7 +24,7 @@ namespace TinyCsvParser
             return mapping.GetPropertyMapping();
         }
 
-        public (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) Parse(IEnumerable<Row> csvData)
+        public CsvData<TEntity> Parse(IEnumerable<Row> csvData)
         {
             CsvHeaderMappingResult csvMappingHeader = null;
             if (csvData == null)
@@ -62,9 +62,13 @@ namespace TinyCsvParser
                 query = query.Where(line => !line.Data.StartsWith(options.CommentCharacter));
             }
 
-            return (query
-                .Select(line => new TokenizedRow(line.Index, options.Tokenizer.Tokenize(line.Data)))
-                .Select(fields => mapping.Map(fields)), csvMappingHeader);
+            return new CsvData<TEntity>
+            {
+                Header = csvMappingHeader,
+                Items = query
+                    .Select(line => new TokenizedRow(line.Index, options.Tokenizer.Tokenize(line.Data)))
+                    .Select(fields => mapping.Map(fields))
+            };
         }
 
         public override string ToString()

--- a/TinyCsvParser/TinyCsvParser/CsvParser.cs
+++ b/TinyCsvParser/TinyCsvParser/CsvParser.cs
@@ -19,6 +19,11 @@ namespace TinyCsvParser
             this.mapping = mapping;
         }
 
+        public Dictionary<int, string> GetPropertyMapping()
+        {
+            return mapping.GetPropertyMapping();
+        }
+
         public (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) Parse(IEnumerable<Row> csvData)
         {
             CsvHeaderMappingResult csvMappingHeader = null;

--- a/TinyCsvParser/TinyCsvParser/CsvParserExtensions.cs
+++ b/TinyCsvParser/TinyCsvParser/CsvParserExtensions.cs
@@ -12,7 +12,7 @@ namespace TinyCsvParser
 {
     public static class CsvParserExtensions
     {
-        public static ParallelQuery<CsvMappingResult<TEntity>> ReadFromFile<TEntity>(this ICsvParser<TEntity> csvParser, string fileName, Encoding encoding)
+        public static (ParallelQuery<CsvMappingResult<TEntity>> data, CsvHeaderMappingResult header) ReadFromFile<TEntity>(this ICsvParser<TEntity> csvParser, string fileName, Encoding encoding)
         {
             if (fileName == null)
             {
@@ -26,7 +26,7 @@ namespace TinyCsvParser
             return csvParser.Parse(lines);
         }
 
-        public static ParallelQuery<CsvMappingResult<TEntity>> ReadFromString<TEntity>(this ICsvParser<TEntity> csvParser, CsvReaderOptions csvReaderOptions, string csvData)
+        public static (ParallelQuery<CsvMappingResult<TEntity>> data, CsvHeaderMappingResult header) ReadFromString<TEntity>(this ICsvParser<TEntity> csvParser, CsvReaderOptions csvReaderOptions, string csvData)
         {
             var lines = csvData
                 .Split(csvReaderOptions.NewLine, StringSplitOptions.None)
@@ -46,7 +46,7 @@ namespace TinyCsvParser
             }
         }
 
-        public static ParallelQuery<CsvMappingResult<TEntity>> ReadFromStream<TEntity>(this ICsvParser<TEntity> csvParser, Stream stream, Encoding encoding, bool detectEncodingFromByteOrderMarks = false, int bufferSize = 1024, bool leaveOpen = false)
+        public static (ParallelQuery<CsvMappingResult<TEntity>> data, CsvHeaderMappingResult header) ReadFromStream<TEntity>(this ICsvParser<TEntity> csvParser, Stream stream, Encoding encoding, bool detectEncodingFromByteOrderMarks = false, int bufferSize = 1024, bool leaveOpen = false)
         {
             if (stream == null)
             {

--- a/TinyCsvParser/TinyCsvParser/CsvParserExtensions.cs
+++ b/TinyCsvParser/TinyCsvParser/CsvParserExtensions.cs
@@ -12,7 +12,7 @@ namespace TinyCsvParser
 {
     public static class CsvParserExtensions
     {
-        public static (ParallelQuery<CsvMappingResult<TEntity>> data, CsvHeaderMappingResult header) ReadFromFile<TEntity>(this ICsvParser<TEntity> csvParser, string fileName, Encoding encoding)
+        public static (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) ReadFromFile<TEntity>(this ICsvParser<TEntity> csvParser, string fileName, Encoding encoding)
         {
             if (fileName == null)
             {
@@ -26,7 +26,7 @@ namespace TinyCsvParser
             return csvParser.Parse(lines);
         }
 
-        public static (ParallelQuery<CsvMappingResult<TEntity>> data, CsvHeaderMappingResult header) ReadFromString<TEntity>(this ICsvParser<TEntity> csvParser, CsvReaderOptions csvReaderOptions, string csvData)
+        public static (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) ReadFromString<TEntity>(this ICsvParser<TEntity> csvParser, CsvReaderOptions csvReaderOptions, string csvData)
         {
             var lines = csvData
                 .Split(csvReaderOptions.NewLine, StringSplitOptions.None)
@@ -46,7 +46,7 @@ namespace TinyCsvParser
             }
         }
 
-        public static (ParallelQuery<CsvMappingResult<TEntity>> data, CsvHeaderMappingResult header) ReadFromStream<TEntity>(this ICsvParser<TEntity> csvParser, Stream stream, Encoding encoding, bool detectEncodingFromByteOrderMarks = false, int bufferSize = 1024, bool leaveOpen = false)
+        public static (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) ReadFromStream<TEntity>(this ICsvParser<TEntity> csvParser, Stream stream, Encoding encoding, bool detectEncodingFromByteOrderMarks = false, int bufferSize = 1024, bool leaveOpen = false)
         {
             if (stream == null)
             {

--- a/TinyCsvParser/TinyCsvParser/CsvParserExtensions.cs
+++ b/TinyCsvParser/TinyCsvParser/CsvParserExtensions.cs
@@ -5,14 +5,13 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using TinyCsvParser.Mapping;
 using TinyCsvParser.Model;
 
 namespace TinyCsvParser
 {
     public static class CsvParserExtensions
     {
-        public static (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) ReadFromFile<TEntity>(this ICsvParser<TEntity> csvParser, string fileName, Encoding encoding)
+        public static CsvData<TEntity> ReadFromFile<TEntity>(this ICsvParser<TEntity> csvParser, string fileName, Encoding encoding)
         {
             if (fileName == null)
             {
@@ -26,7 +25,7 @@ namespace TinyCsvParser
             return csvParser.Parse(lines);
         }
 
-        public static (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) ReadFromString<TEntity>(this ICsvParser<TEntity> csvParser, CsvReaderOptions csvReaderOptions, string csvData)
+        public static CsvData<TEntity> ReadFromString<TEntity>(this ICsvParser<TEntity> csvParser, CsvReaderOptions csvReaderOptions, string csvData)
         {
             var lines = csvData
                 .Split(csvReaderOptions.NewLine, StringSplitOptions.None)
@@ -46,7 +45,7 @@ namespace TinyCsvParser
             }
         }
 
-        public static (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) ReadFromStream<TEntity>(this ICsvParser<TEntity> csvParser, Stream stream, Encoding encoding, bool detectEncodingFromByteOrderMarks = false, int bufferSize = 1024, bool leaveOpen = false)
+        public static CsvData<TEntity> ReadFromStream<TEntity>(this ICsvParser<TEntity> csvParser, Stream stream, Encoding encoding, bool detectEncodingFromByteOrderMarks = false, int bufferSize = 1024, bool leaveOpen = false)
         {
             if (stream == null)
             {

--- a/TinyCsvParser/TinyCsvParser/CsvParserOptions.cs
+++ b/TinyCsvParser/TinyCsvParser/CsvParserOptions.cs
@@ -16,13 +16,8 @@ namespace TinyCsvParser
         public readonly int DegreeOfParallelism;
 
         public readonly bool KeepOrder;
-        public bool ReadHeader { get; private set; }
 
-        public CsvParserOptions WithReadHeader()
-        {
-            ReadHeader = true;
-            return this;
-        }
+        public bool ReadHeader { get; private set; }
 
         public CsvParserOptions(bool skipHeader, char fieldsSeparator)
             : this(skipHeader, new QuotedStringTokenizer(fieldsSeparator))
@@ -61,6 +56,12 @@ namespace TinyCsvParser
             Tokenizer = tokenizer;
             DegreeOfParallelism = degreeOfParallelism;
             KeepOrder = keepOrder;
+        }
+
+        public CsvParserOptions WithReadHeader()
+        {
+            ReadHeader = true;
+            return this;
         }
 
         public override string ToString()

--- a/TinyCsvParser/TinyCsvParser/CsvParserOptions.cs
+++ b/TinyCsvParser/TinyCsvParser/CsvParserOptions.cs
@@ -8,7 +8,7 @@ namespace TinyCsvParser
     public class CsvParserOptions
     {
         public readonly ITokenizer Tokenizer;
-        
+
         public readonly bool SkipHeader;
 
         public readonly string CommentCharacter;
@@ -16,6 +16,13 @@ namespace TinyCsvParser
         public readonly int DegreeOfParallelism;
 
         public readonly bool KeepOrder;
+        public bool ReadHeader { get; private set; }
+
+        public CsvParserOptions WithReadHeader()
+        {
+            ReadHeader = true;
+            return this;
+        }
 
         public CsvParserOptions(bool skipHeader, char fieldsSeparator)
             : this(skipHeader, new QuotedStringTokenizer(fieldsSeparator))
@@ -23,6 +30,16 @@ namespace TinyCsvParser
         }
 
         public CsvParserOptions(bool skipHeader, char fieldsSeparator, int degreeOfParallelism, bool keepOrder)
+            : this(skipHeader, string.Empty, new QuotedStringTokenizer(fieldsSeparator), degreeOfParallelism, keepOrder)
+        {
+        }
+
+        public CsvParserOptions(bool skipHeader, char[] fieldsSeparator)
+            : this(skipHeader, new QuotedStringTokenizer(fieldsSeparator))
+        {
+        }
+
+        public CsvParserOptions(bool skipHeader, char[] fieldsSeparator, int degreeOfParallelism, bool keepOrder)
             : this(skipHeader, string.Empty, new QuotedStringTokenizer(fieldsSeparator), degreeOfParallelism, keepOrder)
         {
         }

--- a/TinyCsvParser/TinyCsvParser/ICsvParser.cs
+++ b/TinyCsvParser/TinyCsvParser/ICsvParser.cs
@@ -9,7 +9,13 @@ namespace TinyCsvParser
 {
     public interface ICsvParser<TEntity>
     {
-        (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) Parse(IEnumerable<Row> csvData);
+        CsvData<TEntity> Parse(IEnumerable<Row> csvData);
         Dictionary<int, string> GetPropertyMapping();
+    }
+
+    public class CsvData<TEntity>
+    {
+        public CsvHeaderMappingResult Header { get; set; }
+        public ParallelQuery<CsvMappingResult<TEntity>> Items { get; set; }
     }
 }

--- a/TinyCsvParser/TinyCsvParser/ICsvParser.cs
+++ b/TinyCsvParser/TinyCsvParser/ICsvParser.cs
@@ -10,5 +10,6 @@ namespace TinyCsvParser
     public interface ICsvParser<TEntity>
     {
         (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) Parse(IEnumerable<Row> csvData);
+        Dictionary<int, string> GetPropertyMapping();
     }
 }

--- a/TinyCsvParser/TinyCsvParser/ICsvParser.cs
+++ b/TinyCsvParser/TinyCsvParser/ICsvParser.cs
@@ -9,6 +9,6 @@ namespace TinyCsvParser
 {
     public interface ICsvParser<TEntity>
     {
-        ParallelQuery<CsvMappingResult<TEntity>> Parse(IEnumerable<Row> csvData);
+        (ParallelQuery<CsvMappingResult<TEntity>> result, CsvHeaderMappingResult header) Parse(IEnumerable<Row> csvData);
     }
 }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
@@ -138,7 +138,7 @@ namespace TinyCsvParser.Mapping
                     RowIndex = values.Index,
                     Error = new CsvMappingError
                     {
-                        Value = $"Unexpected number Columns, requires {csvIndexPropertyMappings.Count}, found {values.Tokens.Length}",
+                        Value = $"Unexpected number of columns, requires {csvIndexPropertyMappings.Count}, found {values.Tokens.Length}",
                         UnmappedRow = string.Join("|", values.Tokens),
                         ErrorCode = CsvParserErrorCodes.NumberOfColumnsNotEqualToProperties
                     }
@@ -269,7 +269,7 @@ namespace TinyCsvParser.Mapping
                     RowIndex = values.Index,
                     Error = new CsvMappingError
                     {
-                        Value = $"Unexpected number Columns, requires {csvIndexPropertyMappings.Count} found {values.Tokens.Length}",
+                        Value = $"Unexpected number of columns, requires {csvIndexPropertyMappings.Count} found {values.Tokens.Length}",
                         UnmappedRow = string.Join("|", values.Tokens),
                         ErrorCode = CsvParserErrorCodes.NumberOfColumnsNotEqualToProperties
                     }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
@@ -13,11 +13,17 @@ namespace TinyCsvParser.Mapping
     public abstract class CsvMapping<TEntity> : ICsvMapping<TEntity>
         where TEntity : class, new()
     {
+        public Dictionary<int, string> GetPropertyMapping()
+        {
+            return csvIndexPropertyMappings.ToDictionary(x => x.ColumnIndex, x => x.PropertyName);
+        }
+
         private class IndexToPropertyMapping
         {
             public int ColumnIndex { get; set; }
 
             public ICsvPropertyMapping<TEntity, string> PropertyMapping { get; set; }
+            public string PropertyName { get; set; }
 
             public override string ToString()
             {
@@ -93,18 +99,18 @@ namespace TinyCsvParser.Mapping
 
             var propertyMapping = new CsvPropertyMapping<TEntity, TProperty>(property, typeConverter);
 
-            AddPropertyMapping(columnIndex, propertyMapping);
+            AddPropertyMapping(columnIndex, propertyMapping, property);
 
             return propertyMapping;
         }
 
-
-        private void AddPropertyMapping<TProperty>(int columnIndex, CsvPropertyMapping<TEntity, TProperty> propertyMapping)
+        private void AddPropertyMapping<TProperty>(int columnIndex, CsvPropertyMapping<TEntity, TProperty> propertyMapping, Expression<Func<TEntity, TProperty>> property)
         {
             var indexToPropertyMapping = new IndexToPropertyMapping
             {
                 ColumnIndex = columnIndex,
-                PropertyMapping = propertyMapping
+                PropertyMapping = propertyMapping,
+                PropertyName = ((MemberExpression)property.Body).Member.Name
             };
 
             csvIndexPropertyMappings.Add(indexToPropertyMapping);

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
@@ -140,7 +140,7 @@ namespace TinyCsvParser.Mapping
                     {
                         Value = $"Unexpected number Columns, requires {csvIndexPropertyMappings.Count}, found {values.Tokens.Length}",
                         UnmappedRow = string.Join("|", values.Tokens),
-                        ErrorCode = CsvParserErrorCodes.ColumnsExceedNumberOfProperties
+                        ErrorCode = CsvParserErrorCodes.NumberOfColumnsNotEqualToProperties
                     }
                 };
             }
@@ -271,7 +271,7 @@ namespace TinyCsvParser.Mapping
                     {
                         Value = $"Unexpected number Columns, requires {csvIndexPropertyMappings.Count} found {values.Tokens.Length}",
                         UnmappedRow = string.Join("|", values.Tokens),
-                        ErrorCode = CsvParserErrorCodes.ColumnsExceedNumberOfProperties
+                        ErrorCode = CsvParserErrorCodes.NumberOfColumnsNotEqualToProperties
                     }
                 };
             }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
@@ -125,14 +125,14 @@ namespace TinyCsvParser.Mapping
         {
             TEntity entity = new TEntity();
 
-            if (values.Tokens.Length > csvIndexPropertyMappings.Count)
+            if (values.Tokens.Length != csvIndexPropertyMappings.Count)
             {
                 return new CsvMappingResult<TEntity>
                 {
                     RowIndex = values.Index,
                     Error = new CsvMappingError
                     {
-                        Value = "Columns exceeds number of properties",
+                        Value = $"Unexpected number Columns, requires {csvIndexPropertyMappings.Count}, found {values.Tokens.Length}",
                         UnmappedRow = string.Join("|", values.Tokens),
                         ErrorCode = CsvParserErrorCodes.ColumnsExceedNumberOfProperties
                     }
@@ -256,6 +256,19 @@ namespace TinyCsvParser.Mapping
         {
             var headerValues = new List<string>();
 
+            if (values.Tokens.Length != csvIndexPropertyMappings.Count)
+            {
+                return new CsvHeaderMappingResult
+                {
+                    RowIndex = values.Index,
+                    Error = new CsvMappingError
+                    {
+                        Value = $"Unexpected number Columns, requires {csvIndexPropertyMappings.Count} found {values.Tokens.Length}",
+                        UnmappedRow = string.Join("|", values.Tokens),
+                        ErrorCode = CsvParserErrorCodes.ColumnsExceedNumberOfProperties
+                    }
+                };
+            }
             // Iterate over Index Mappings:
             for (int pos = 0; pos < csvIndexPropertyMappings.Count; pos++)
             {
@@ -272,7 +285,8 @@ namespace TinyCsvParser.Mapping
                         {
                             ColumnIndex = columnIndex,
                             Value = $"Column {columnIndex} is Out Of Range",
-                            UnmappedRow = string.Join("|", values.Tokens)
+                            UnmappedRow = string.Join("|", values.Tokens),
+                            ErrorCode = CsvParserErrorCodes.OutOfRange
                         }
                     };
                 }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
@@ -181,7 +181,7 @@ namespace TinyCsvParser.Mapping
                         };
                     }
 
-                    columnMappingResult.Error.ColumnValues[columnIndex] = value;
+                    columnMappingResult.Error.InvalidColumnValues[columnIndex] = value;
                 }
             }
 
@@ -216,7 +216,7 @@ namespace TinyCsvParser.Mapping
                             }
                         };
 
-                        columnMappingResult.Error.ColumnValues[columnIndex] = value;
+                        columnMappingResult.Error.InvalidColumnValues[columnIndex] = string.Join(",", slice);
                     }
                 }
             }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
@@ -134,7 +134,7 @@ namespace TinyCsvParser.Mapping
                     {
                         Value = "Columns exceeds number of properties",
                         UnmappedRow = string.Join("|", values.Tokens),
-                        ErrorCode = CsvParserErrorCodes.ColumnsExceedProperties
+                        ErrorCode = CsvParserErrorCodes.ColumnsExceedNumberOfProperties
                     }
                 };
             }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMapping.cs
@@ -238,7 +238,8 @@ namespace TinyCsvParser.Mapping
                         Error = new CsvMappingError
                         {
                             Value = $"Row could not be mapped!",
-                            UnmappedRow = string.Join("|", values.Tokens)
+                            UnmappedRow = string.Join("|", values.Tokens),
+                            ErrorCode = CsvParserErrorCodes.OutOfRange
                         }
                     };
                 }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMappingError.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMappingError.cs
@@ -1,5 +1,7 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace TinyCsvParser.Mapping
 {
     public class CsvMappingError
@@ -10,9 +12,19 @@ namespace TinyCsvParser.Mapping
 
         public string UnmappedRow { get; set; }
 
+        public Dictionary<int, string> ColumnValues { get; set; } = new Dictionary<int, string>();
+        public CsvParserErrorCodes ErrorCode;
+
         public override string ToString()
         {
             return $"CsvMappingError (ColumnIndex = {ColumnIndex}, Value = {Value}, UnmappedRow = {UnmappedRow})";
         }
+    }
+
+    public enum CsvParserErrorCodes
+    {
+        ColumnsExceedProperties,
+        InvalidColumnData,
+        OutOfRange
     }
 }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMappingError.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMappingError.cs
@@ -12,7 +12,7 @@ namespace TinyCsvParser.Mapping
 
         public string UnmappedRow { get; set; }
 
-        public Dictionary<int, string> ColumnValues { get; set; } = new Dictionary<int, string>();
+        public Dictionary<int, string> InvalidColumnValues { get; set; } = new Dictionary<int, string>();
         public CsvParserErrorCodes ErrorCode;
 
         public override string ToString()

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMappingError.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMappingError.cs
@@ -23,7 +23,7 @@ namespace TinyCsvParser.Mapping
 
     public enum CsvParserErrorCodes
     {
-        ColumnsExceedProperties,
+        ColumnsExceedNumberOfProperties,
         InvalidColumnData,
         OutOfRange
     }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMappingError.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMappingError.cs
@@ -23,7 +23,7 @@ namespace TinyCsvParser.Mapping
 
     public enum CsvParserErrorCodes
     {
-        ColumnsExceedNumberOfProperties,
+        NumberOfColumnsNotEqualToProperties,
         InvalidColumnData,
         OutOfRange
     }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvMappingResult.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvMappingResult.cs
@@ -1,20 +1,30 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace TinyCsvParser.Mapping
 {
-    public class CsvMappingResult<TEntity>
+    public abstract class CsvMappingResultBase
     {
         public int RowIndex { get; set; }
 
         public CsvMappingError Error { get; set; }
 
-        public TEntity Result { get; set; }
-
         public bool IsValid { get { return Error == null; } }
+    }
+
+    public class CsvMappingResult<TEntity> : CsvMappingResultBase
+    {
+        public TEntity Result { get; set; }
 
         public override string ToString()
         {
             return $"CsvMappingResult (Error = {Error}, Result = {Result})";
         }
+    }
+
+    public class CsvHeaderMappingResult : CsvMappingResultBase
+    {
+        public List<string> Values { get; set; }
     }
 }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvStringArrayMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvStringArrayMapping.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using TinyCsvParser.Model;
 
 namespace TinyCsvParser.Mapping
@@ -16,6 +17,11 @@ namespace TinyCsvParser.Mapping
         }
 
         public CsvHeaderMappingResult MapHeader(TokenizedRow values)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Dictionary<int, string> GetPropertyMapping()
         {
             throw new System.NotImplementedException();
         }

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvStringArrayMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvStringArrayMapping.cs
@@ -7,7 +7,7 @@ namespace TinyCsvParser.Mapping
 {
     public class CsvStringArrayMapping : ICsvMapping<string[]>
     {
-        public CsvMappingResult<string[]> Map(TokenizedRow values)
+        public CsvMappingResult<string[]> Map(TokenizedRow values, int ignoreColumns = 0)
         {
             return new CsvMappingResult<string[]>
             {

--- a/TinyCsvParser/TinyCsvParser/Mapping/CsvStringArrayMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/CsvStringArrayMapping.cs
@@ -8,10 +8,16 @@ namespace TinyCsvParser.Mapping
     {
         public CsvMappingResult<string[]> Map(TokenizedRow values)
         {
-            return new CsvMappingResult<string[]> {
-                RowIndex =  values.Index,
+            return new CsvMappingResult<string[]>
+            {
+                RowIndex = values.Index,
                 Result = values.Tokens
             };
+        }
+
+        public CsvHeaderMappingResult MapHeader(TokenizedRow values)
+        {
+            throw new System.NotImplementedException();
         }
     }
 }

--- a/TinyCsvParser/TinyCsvParser/Mapping/ICsvMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/ICsvMapping.cs
@@ -7,5 +7,6 @@ namespace TinyCsvParser.Mapping
     public interface ICsvMapping<TEntity>
     {
         CsvMappingResult<TEntity> Map(TokenizedRow values);
+        CsvHeaderMappingResult MapHeader(TokenizedRow values);
     }
 }

--- a/TinyCsvParser/TinyCsvParser/Mapping/ICsvMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/ICsvMapping.cs
@@ -7,7 +7,7 @@ namespace TinyCsvParser.Mapping
 {
     public interface ICsvMapping<TEntity>
     {
-        CsvMappingResult<TEntity> Map(TokenizedRow values);
+        CsvMappingResult<TEntity> Map(TokenizedRow values, int ignoreColumns = 0);
         CsvHeaderMappingResult MapHeader(TokenizedRow values);
         Dictionary<int, string> GetPropertyMapping();
     }

--- a/TinyCsvParser/TinyCsvParser/Mapping/ICsvMapping.cs
+++ b/TinyCsvParser/TinyCsvParser/Mapping/ICsvMapping.cs
@@ -1,5 +1,6 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
 using TinyCsvParser.Model;
 
 namespace TinyCsvParser.Mapping
@@ -8,5 +9,6 @@ namespace TinyCsvParser.Mapping
     {
         CsvMappingResult<TEntity> Map(TokenizedRow values);
         CsvHeaderMappingResult MapHeader(TokenizedRow values);
+        Dictionary<int, string> GetPropertyMapping();
     }
 }

--- a/TinyCsvParser/TinyCsvParser/Tokenizer/QuotedStringTokenizer.cs
+++ b/TinyCsvParser/TinyCsvParser/Tokenizer/QuotedStringTokenizer.cs
@@ -7,14 +7,19 @@ namespace TinyCsvParser.Tokenizer
     public class QuotedStringTokenizer : RFC4180Tokenizer
     {
         public QuotedStringTokenizer(char columnDelimiter)
+            : this('"', '\\', new char[] { columnDelimiter })
+        {
+        }
+
+        public QuotedStringTokenizer(char[] columnDelimiter)
             : this('"', '\\', columnDelimiter)
         {
         }
 
-        public QuotedStringTokenizer(char quoteCharacter, char escapeCharacter, char columnDelimiter)
+        public QuotedStringTokenizer(char quoteCharacter, char escapeCharacter, char[] columnDelimiter)
             : base(new Options(quoteCharacter, escapeCharacter, columnDelimiter))
         {
-        }        
+        }
 
         public override string ToString()
         {

--- a/TinyCsvParser/TinyCsvParser/Tokenizer/RFC4180/Options.cs
+++ b/TinyCsvParser/TinyCsvParser/Tokenizer/RFC4180/Options.cs
@@ -19,6 +19,11 @@ namespace TinyCsvParser.Tokenizer.RFC4180
             StrictDelimitation = strictDelimitation;
         }
 
+        public Options(char quoteCharacter, char escapeCharacter, char delimiterCharacter, bool strictDelimitation = false) 
+            : this(quoteCharacter, escapeCharacter, new char[] { delimiterCharacter }, strictDelimitation)
+        {
+        }
+
         public override string ToString()
         {
             return $"Options (QuoteCharacter = {QuoteCharacter}, EscapeCharacter = {EscapeCharacter}, DelimiterCharacter = {DelimiterCharacter}, StrictDelimitation = {StrictDelimitation})";

--- a/TinyCsvParser/TinyCsvParser/Tokenizer/RFC4180/Options.cs
+++ b/TinyCsvParser/TinyCsvParser/Tokenizer/RFC4180/Options.cs
@@ -1,19 +1,21 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+
 namespace TinyCsvParser.Tokenizer.RFC4180
 {
     public class Options
     {
         public readonly char QuoteCharacter;
         public readonly char EscapeCharacter;
-        public readonly char DelimiterCharacter;
+        public readonly HashSet<char> DelimiterCharacter;
         public readonly bool StrictDelimitation;
 
-        public Options(char quoteCharacter, char escapeCharacter, char delimiterCharacter, bool strictDelimitation = false)
+        public Options(char quoteCharacter, char escapeCharacter, char[] delimiterCharacter, bool strictDelimitation = false)
         {
             QuoteCharacter = quoteCharacter;
             EscapeCharacter = escapeCharacter;
-            DelimiterCharacter = delimiterCharacter;
+            DelimiterCharacter = new HashSet<char>(delimiterCharacter);
             StrictDelimitation = strictDelimitation;
         }
 

--- a/TinyCsvParser/TinyCsvParser/Tokenizer/RFC4180/Reader.cs
+++ b/TinyCsvParser/TinyCsvParser/Tokenizer/RFC4180/Reader.cs
@@ -45,7 +45,7 @@ namespace TinyCsvParser.Tokenizer.RFC4180
             while (true)
             {
                 Token token = NextToken(reader);
-               
+
                 tokens.Add(token);
 
                 if (token.Type == TokenType.EndOfRecord)
@@ -63,8 +63,8 @@ namespace TinyCsvParser.Tokenizer.RFC4180
             string result = string.Empty;
 
             int c = reader.Peek();
-            
-            if (c == options.DelimiterCharacter)
+
+            if (options.DelimiterCharacter.Contains((char)(c)))
             {
                 reader.Read();
 
@@ -94,10 +94,10 @@ namespace TinyCsvParser.Tokenizer.RFC4180
                     }
                 }
 
-                if (IsEndOfStream(c)) 
+                if (IsEndOfStream(c))
                 {
                     return new Token(TokenType.EndOfRecord);
-                } 
+                }
                 else
                 {
                     result = reader.ReadTo(options.DelimiterCharacter).Trim();
@@ -114,7 +114,7 @@ namespace TinyCsvParser.Tokenizer.RFC4180
                         return new Token(TokenType.EndOfRecord, result);
                     }
 
-                    if(IsDelimiter(reader.Peek())) 
+                    if (IsDelimiter(reader.Peek()))
                     {
                         reader.Read();
                     }
@@ -136,7 +136,7 @@ namespace TinyCsvParser.Tokenizer.RFC4180
             {
                 return result;
             }
-         
+
             StringBuilder buffer = new StringBuilder(result);
             do
             {
@@ -157,10 +157,11 @@ namespace TinyCsvParser.Tokenizer.RFC4180
             }
         }
 
-        private bool IsQuoteCharacter(int c) {
+        private bool IsQuoteCharacter(int c)
+        {
             return c == options.QuoteCharacter;
         }
-        
+
         private bool IsEndOfStream(int c)
         {
             return c == -1;
@@ -168,7 +169,7 @@ namespace TinyCsvParser.Tokenizer.RFC4180
 
         private bool IsDelimiter(int c)
         {
-            return c == options.DelimiterCharacter;
+            return options.DelimiterCharacter.Contains((char)c);
         }
 
         private bool IsWhiteSpace(int c)

--- a/TinyCsvParser/TinyCsvParser/Tokenizer/RFC4180/Reader.cs
+++ b/TinyCsvParser/TinyCsvParser/Tokenizer/RFC4180/Reader.cs
@@ -70,58 +70,42 @@ namespace TinyCsvParser.Tokenizer.RFC4180
 
                 return new Token(TokenType.Token);
             }
-            else
+
+            if (!options.StrictDelimitation)
             {
-                if (!options.StrictDelimitation)
+                if (IsQuoteCharacter(c))
                 {
-                    if (IsQuoteCharacter(c))
-                    {
-                        result = ReadQuoted(reader);
-
-                        Skip(reader);
-
-                        if (IsEndOfStream(reader.Peek()))
-                        {
-                            return new Token(TokenType.EndOfRecord, result);
-                        }
-
-                        if (IsDelimiter(reader.Peek()))
-                        {
-                            reader.Read();
-                        }
-
-                        return new Token(TokenType.Token, result);
-                    }
-                }
-
-                if (IsEndOfStream(c))
-                {
-                    return new Token(TokenType.EndOfRecord);
-                }
-                else
-                {
-                    result = reader.ReadTo(options.DelimiterCharacter).Trim();
-
-                    if (options.StrictDelimitation)
-                    {
-                        result = result.TrimStart(options.QuoteCharacter).TrimEnd(options.QuoteCharacter);
-                    }
+                    result = ReadQuoted(reader);
 
                     Skip(reader);
 
                     if (IsEndOfStream(reader.Peek()))
-                    {
                         return new Token(TokenType.EndOfRecord, result);
-                    }
 
                     if (IsDelimiter(reader.Peek()))
-                    {
                         reader.Read();
-                    }
 
                     return new Token(TokenType.Token, result);
                 }
             }
+
+            if (IsEndOfStream(c))
+                return new Token(TokenType.EndOfRecord);
+
+            result = reader.ReadTo(options.DelimiterCharacter).Trim();
+
+            if (options.StrictDelimitation)
+                result = result.TrimStart(options.QuoteCharacter).TrimEnd(options.QuoteCharacter);
+
+            Skip(reader);
+
+            if (IsEndOfStream(reader.Peek()))
+                return new Token(TokenType.EndOfRecord, result);
+
+            if (IsDelimiter(reader.Peek()))
+                reader.Read();
+
+            return new Token(TokenType.Token, result);
         }
 
         private string ReadQuoted(StringReader reader)

--- a/TinyCsvParser/TinyCsvParser/Tokenizer/RFC4180/StringReaderExtensions.cs
+++ b/TinyCsvParser/TinyCsvParser/Tokenizer/RFC4180/StringReaderExtensions.cs
@@ -1,24 +1,23 @@
 ﻿// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace TinyCsvParser.Tokenizer.RFC4180
 {
     public static class StringReaderExtensions
     {
-        public static string ReadTo(this StringReader reader, char readTo)
+        public static string ReadTo(this StringReader reader, HashSet<char> readTo)
         {
             StringBuilder buffer = new StringBuilder();
-            while(reader.Peek() != -1 && reader.Peek() != readTo) 
+            while (reader.Peek() != -1 && !readTo.Contains((char)reader.Peek()))
             {
-                buffer.Append((char) reader.Read());
+                buffer.Append((char)reader.Read());
             }
             return buffer.ToString();
         }
+        public static string ReadTo(this StringReader reader, char readTo)
+            => reader.ReadTo(new HashSet<char>(new char[] { readTo }));
     }
 }


### PR DESCRIPTION
This PR includes some additional validations to return a list of columns that failed to be parsed, as currently it returns the column that failed to be parsed.  In addition, I have added a feature to return the headers of the csv, and also another validation that if any row has more columns than the indices, it returns an error - for instance having 4 columns, but rows contain more than 4 columns.

The idea is to return a list of validations to the user so that the majority of the errors can be fixed without re-validating the csv again - for instance avoiding uploading the csv to the server and validating which would save bandwidth and time