### PR TITLE
Update TargetFrameworks

### DIFF
--- a/TinyCsvParser/TinyCsvParser.Benchmark/TinyCsvParser.Benchmark.csproj
+++ b/TinyCsvParser/TinyCsvParser.Benchmark/TinyCsvParser.Benchmark.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TinyCsvParser/TinyCsvParser.Test/GlobalUsings.cs
+++ b/TinyCsvParser/TinyCsvParser.Test/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Assert = NUnit.Framework.Legacy.ClassicAssert;

--- a/TinyCsvParser/TinyCsvParser.Test/TinyCsvParser.Test.csproj
+++ b/TinyCsvParser/TinyCsvParser.Test/TinyCsvParser.Test.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFramework>net9.0</TargetFramework>
 	  <ImplicitUsings>disable</ImplicitUsings>
 	  <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TinyCsvParser/TinyCsvParser/TinyCsvParser.csproj
+++ b/TinyCsvParser/TinyCsvParser/TinyCsvParser.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <Authors>Philipp Wagner</Authors>
     <Company />
     <Product />


### PR DESCRIPTION
Hi,

Here is a PR for this Issue #97. I have 8 failing unit test, but those are failing in main too so not sure what's happening there.

Changelog:
- Add support for .NET8/9 
- Remove .NET6 (it has reached the end of support)
- Update nuget pkgs
